### PR TITLE
Resolve numpy.int deprecation issues

### DIFF
--- a/src/specFunctions.py
+++ b/src/specFunctions.py
@@ -124,8 +124,8 @@ def savitzky_golay(y, window_size, order, deriv=0, rate=1):
 	import numpy as np
 	from math import factorial
 	try:
-		window_size = np.abs(np.int(window_size))
-		order = np.abs(np.int(order))
+		window_size = np.abs(int(window_size))
+		order = np.abs(int(order))
 	except ValueError:
 		raise ValueError("window_size and order have to be of type int")
 	if window_size % 2 != 1 or window_size < 1:


### PR DESCRIPTION
Update for numpy runtime errors. np.int is deprecated and crashed the software, this simple fix makes it work again.